### PR TITLE
curl was not downloading install.sh from pivpn.io

### DIFF
--- a/sh/reconf
+++ b/sh/reconf
@@ -19,7 +19,7 @@ INSTALLER=/etc/pivpn/install.sh
 mkdir -p /usr/local/src/pivpn/
 source  /etc/pivpn/setupVars.conf
 PLAT=Ubuntu
-curl -fsSL0 https://install.pivpn.io -o "${INSTALLER}"
+curl -fsSL https://install.pivpn.io -o "${INSTALLER}"
 sed -i 's/debconf-apt-progress --//g' "${INSTALLER}"
 sed -i '/setStaticIPv4 #/d' "${INSTALLER}"
 sed -i 's/WIREGUARD_SUPPORT=0/WIREGUARD_SUPPORT=1/g' "${INSTALLER}"


### PR DESCRIPTION
removed -0 option from curl which was forcing http1.0 and causing piv…pn install.sh download to fail. now letting curl decide http version